### PR TITLE
DOC-4083-Link fixes to content and minor editorial fixes

### DIFF
--- a/docs-book/master_middleman/source/subnavs/solace-pubsub_subnav.erb
+++ b/docs-book/master_middleman/source/subnavs/solace-pubsub_subnav.erb
@@ -7,7 +7,7 @@
     <ul class="menu">
       <li>
         <span class="topic">
-          <a id='home-nav-link' href="/solace-pubsub/index.html">Solace PubSub+ for PCF Overview</a>
+          <a id='home-nav-link' href="/solace-pubsub/index.html">Solace PubSub+ for VMware Tanzu Overview</a>
           <li>
             <span><a href="/solace-pubsub/service-plans.html">Service Plans</a></span>
           </li>

--- a/docs-content/credentials.html.md.erb
+++ b/docs-content/credentials.html.md.erb
@@ -362,13 +362,13 @@ The following credentials are those of a service key created for the same servic
 
 The availability of some of the Credentials fields and their contents will depend on the enabled or disabled features of the Solace tile at installation time as well as the plan type of the service instance.
 
-If a Solace PubSub+ service instance was created using the `enterprise-medium-ha` or `enterprise-large-ha` service plan, it will be highly available. In these cases there will be two separate service URIs for each of the available transports as shown in the example above. Connecting apps use both of these URIs by reconnecting to the other if one of them becomes unavailable. This is known as the *host list* HA failover mechanism. For more information, see the [Solace documentation](https://docs.solace.com/Features/SW-Broker-Redundancy-and-Fault-Tolerance.htm#Failover).
+If a Solace PubSub+ service instance was created using the `enterprise-medium-ha` or `enterprise-large-ha` service plan, it will be highly available. In these cases there will be two separate service URIs for each of the available transports as shown in the example above. Connecting apps use both of these URIs by reconnecting to the other if one of them becomes unavailable. This is known as the *host list* HA failover mechanism. For more information, see the [Solace documentation](https://docs.solace.com/Features/HA-Redundancy/SW-Broker-Redundancy-and-Fault-Tolerance.htm).
 
 If a Solace PubSub+ service instance was created using the `enterprise-shared`, `enterprise-large`, `standard-medium`, or `standard-large` service plan, it will not be highly available. In these cases, there will only be one URI for each of the supported transports.
 
 When LDAP is enabled, and Management Access is set to `LDAP Server`, `managementUsername` and `managementPassword` is not available.
 
-When LDAP is enabled, and Application Access is set to `LDAP Server`, `clientUsername` and `clientPassword` is not available. The tile installation has taken care of creating an LDAP profile, and setting it as the auth-type for each Message VPN. However, an administrator with Management Access must create the necessary LDAP Groups on the Solace PubSub+ Event Broker for each Message VPN using SEMP or SolAdmin in order to grant the necessary access to the app. For more information, see [Configuring Client LDAP Authorization](http://docs.solace.com/Configuring-and-Managing-Routers/Configuring-LDAP-Groups.htm)
+When LDAP is enabled, and Application Access is set to `LDAP Server`, `clientUsername` and `clientPassword` is not available. The tile installation has taken care of creating an LDAP profile, and setting it as the auth-type for each Message VPN. However, an administrator with Management Access must create the necessary LDAP Groups on the Solace PubSub+ Event Broker for each Message VPN using SEMP or SolAdmin in order to grant the necessary access to the app. For more information, see [Configuring Client LDAP Authorization](https://docs.solace.com/Security/Configuring-LDAP-Groups.htm)
 
 When TCP routes are enabled, additional public fields provide the connectivity details for that messaging protocol so it may be used from an external network source, such as the Internet.
 
@@ -413,8 +413,8 @@ When TCP routes are enabled, additional public fields provide the connectivity d
 | `pulicWebMessagingUris` | Web Messaging | The URLs used to connect the session (solclientjs), or the HOST Session Property (CCSMP, .NET API, and JAVA RTO). Available when TCP Routes is enabled |
 | `publicWebMessagingTlsUris` | Web Messaging | The HTTPS URLs used to connect the session (solclientjs), or the HOST Session Property (CCSMP, .NET API, and JAVA RTO). Available when TCP Routes is enabled |
 | `publicHealthCheckUris` | Health Check | The Health Check URIs that can be used for load balancing from external services. Available when TCP Routes is enabled. |
-| `managementHostnames` | Management (SEMP) | The DNS hostnames associated with the service instance's management service. These are FQDNs on standard ports for HTTP (80) and HTTPS (443) that can be used by management apps external to VMware Tanzu, for example [SolAdmin](http://docs.solace.com/SolAdmin/SolAdmin-Home.htm), to connect to the Solace PubSub+ Event Broker  associated with the service instance. |
-| `activeManagementHostname` | Management (SEMP) | A DNS hostname associated with the active service instance's management service. This is applicable for `enterprise-medium-ha` or `enterprise-large-ha` service plans. The 'activeManagementHostname' will be the same as 'managementHostnames' for non HA plans. This FQDN on standard ports for HTTP (80) and HTTPS (443) can be used by management apps external to VMware Tanzu, for example [SolAdmin](http://docs.solace.com/SolAdmin/SolAdmin-Home.htm), to connect to the Solace PubSub+ Event Broker associated with the service instance |
+| `managementHostnames` | Management (SEMP) | The DNS hostnames associated with the service instance's management service. These are FQDNs on standard ports for HTTP (80) and HTTPS (443) that can be used by management apps external to VMware Tanzu, for example [SolAdmin](https://docs.solace.com/SolAdmin/SolAdmin-Home.htm), to connect to the Solace PubSub+ Event Broker  associated with the service instance. |
+| `activeManagementHostname` | Management (SEMP) | A DNS hostname associated with the active service instance's management service. This is applicable for `enterprise-medium-ha` or `enterprise-large-ha` service plans. The 'activeManagementHostname' will be the same as 'managementHostnames' for non HA plans. This FQDN on standard ports for HTTP (80) and HTTPS (443) can be used by management apps external to VMware Tanzu, for example [SolAdmin](https://docs.solace.com/SolAdmin/SolAdmin-Home.htm), to connect to the Solace PubSub+ Event Broker associated with the service instance |
 | `managementPassword` | Management (SEMP) | The VPN's administrative username. Not available if Management Access is set to `LDAP Server` |
 | `managementUsername` | Management (SEMP) | The VPN's administrative password. Not available if Management Access is set to `LDAP Server` |
 
@@ -424,10 +424,10 @@ The table above matches each field to the messaging protocol it uses. The Solace
 
 * Java Messaging Service (JMS): See the [Oracle documentation](http://www.oracle.com/technetwork/java/index-jsp-142945.html) for more information.
 * MQTT: See the [MQTT documentation](http://mqtt.org/documentation) for more information.
-* AMQP: See the [AMQP documentation](http://dev.solace.com/tech/amqp/) for more information.
-* Solace Message Format (SMF): See the [Solace PubSub+ API documentation](http://docs.solace.com/Solace-Messaging-APIs/Solace-APIs-Overview.htm) for more information.
-* Web Messaging: See the [Solace Web Messaging Concepts documentation](http://docs.solace.com/Features/Web-Messaging-Concepts/Web-Messaging-Intro-js.htm) for more information.
-* REST: See the [Solace REST PubSub+ documentation](http://docs.solace.com/Open-APIs-Protocols/REST-home.htm) for more information.
+* AMQP: See the [AMQP documentation](https://tutorials.solace.dev/java-amqp-qpid-jms2) for more information.
+* Solace Message Format (SMF): See the [SMF])https://docs.solace.com/API/Component-Maps.htm) and [Solace PubSub+ API documentation](https://docs.solace.com/API/Messaging-APIs/Solace-APIs-Overview.htm) for more information.
+* Web Messaging: See the [Solace Web Messaging Concepts documentation](https://docs.solace.com/API/Messaging-APIs/JavaScript-API/Web-Messaging-Concepts/Web-Messaging-Concepts.htm) for more information.
+* REST: See the [Solace REST PubSub+ documentation](https://docs.solace.com/API/Open-APIs-Protocols.htm) for more information.
 
 <p class="note"><strong>Note:</strong> The app needs to provide the Message VPN when using the <code>SMF</code>, <code>JMS</code>, or <code>Web Messaging</code> protocols. As a result, the app needs to read the <code>msgVpnName</code> fields when using those protocols.</p>
 

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -3,9 +3,9 @@ title: Solace PubSub+ for VMware Tanzu
 owner: Partners
 ---
 
-Solace PubSub+ for VMware Tanzu enables you to take advantage of the leading multi-cloud, multi-protocol messaging solution which makes app interconnectivity easy and makes production apps scalable, robust, high-performant, and easy to manage.
+Solace PubSub+ for VMware Tanzu enables you to take advantage of the leading multi-cloud, multi-protocol messaging solution(which makes app--interconnectivity easy). It also makes production apps scalable, robust, high-performant, and easy to manage.
 
-Solace PubSub+ was designed to be deployed across all your IT environments including your non-cloud datacenter, all leading public clouds ([AWS](http://dev.solace.com/clouds/amazon-web-services/), [Azure](http://dev.solace.com/clouds/azure/), and [Google Cloud Platform](http://dev.solace.com/clouds/google-cloud/)) and the popular Platform as a Service, VMware Tanzu, in order to provide a uniform messaging fabric for all your apps and connect them no matter where they are deployed.
+Solace PubSub+ event brokers are designed to be deployed across all your IT environments, including your non-cloud datacenter, all leading public clouds, such as  ([AWS](https://docs.solace.com/Software-Broker/SW-Broker-Set-Up/QuickStarts.htm), [Azure](https://docs.solace.com/Software-Broker/SW-Broker-Set-Up/QuickStarts.htm), and [Google Cloud Platform](https://docs.solace.com/Software-Broker/SW-Broker-Set-Up/QuickStarts.htm)) and the popular Platform as a Service, VMware Tanzu, in order to provide a uniform messaging fabric for all your apps and connect them no matter where they are deployed.
 
 ![alt-text=""](images/solace-environments_newbranding.png)
 
@@ -13,24 +13,24 @@ Solace PubSub+ supports all kinds of messaging APIs, QoS, and data streaming as 
 
 Solace PubSub+ for VMware Tanzu provides plans for both shared event broker instances for cost-effective development as well as a variety of plans for dedicated event brokers of varying performance, scale, and high-availability. Together, they meet the requirements for a range of robust test and production deployments.
 
-One of the key strengths of Solace PubSub+ is its [support for many different open transports and protocols](http://dev.solace.com/tech/#multi-service), making Solace PubSub+ Event Brokers ideal data distribution platforms to connect to any app.
+One of the key strengths of Solace PubSub+ is its support for many different open transports and protocols ([see Messaging APIs and Protocols](http://dev.solace.com/) ), making PubSub+ event brokers ideal for data distribution platforms to connect to any app.
 
 ![alt-text=""](./images/new_solace-overview_new.png)
 
 
 ## <a id='getting-started'></a> Getting Started
 
-In addition to the documentation here, there is also a wealth of information on the [Solace Developer Portal](http://dev.solace.com).
+In addition to the documentation here, there is also information on the [Solace Developer Hub](http://dev.solace.com) that you may find useful.
 
 ### <a id='cloud-operators'></a> Cloud Operators
 
-For cloud operators, the following section shows how to install and configure Solace PubSub+ for VMware Tanzu in your environments.
+For cloud operators, the following section shows you how to install and configure Solace PubSub+ for VMware Tanzu in your environments.
 
 * [Tile Installation and Configuration](installing.html)
 
 ### <a id='developers'></a> Developers
 
-For developers, there are a few resources to help you easily get started with Solace PubSub+ for VMware Tanzu. Within this documentation, see the following sections:
+For developers, there are a few resources to help you easily get started with PubSub+ for VMware Tanzu. Within this documentation, see the following sections:
 
 * [Service Instances](service-instances.html)
 * [Bindings](bindings.html)
@@ -38,9 +38,9 @@ For developers, there are a few resources to help you easily get started with So
 * [Solace PubSub+ Credentials](credentials.html)
 * [Managing the Message VPN](managing.html)
 
-There is also simple sample code which shows you how to easily connect to a Solace PubSub+ Service Instance:
+There is also  sample code which shows you how to connect to a Solace PubSub+ Service Instance:
 
-* [Getting Started Samples](http://dev.solace.com/get-started/pcf-tutorials/) with full source code available in [GitHub](https://github.com/SolaceSamples/solace-samples-cloudfoundry-java)
+* [Getting Started Samples](https://tutorials.solace.dev/tanzu) with full source code available in [GitHub](https://github.com/SolaceSamples/solace-samples-cloudfoundry-java)
 * [Solace PubSub+ Demo App](https://github.com/SolaceLabs/sl-cf-solace-messaging-demo)
 
 
@@ -48,9 +48,9 @@ There is also simple sample code which shows you how to easily connect to a Sola
 
 Solace offers two PubSub+ for VMware Tanzu tiles: the Enterprise Evaluation tile and the Enterprise tile.
 
-The Enterprise Evaluation tile is comprised of two Event Brokers: Solace PubSub+ Standard, and Solace PubSub+ Enterprise Evaluation Edition. PubSub+ Standard is a forever free enterprise-grade event broker that supports publish/subscribe, queueing, request/reply, and streaming, along with integrated high availability (HA) and disaster recovery (DR). The PubSub+ Enterprise Evaluation Edition is a free 90-day evaluation version of the PubSub+ Enterprise edition, which supports all the features of PubSub+ Standard, but with increased performance and scaling. You can download an Enterprise Evaluation tile [here](https://products.solace.com/download/PUBSUB_VMware%20Tanzu_STAND). Also, if you are interested in a support plan for Solace PubSub+ for VMware Tanzu, contact [Solace Support](https://solace.com/support) or your local [Solace sales representative](mailto:info@solace.com). Use the Subject: "Enterprise version of Solace PubSub+ For VMware Tanzu."
+The Enterprise Evaluation tile is comprised of two event brokers: Solace PubSub+ Standard, and Solace PubSub+ Enterprise Evaluation Edition. PubSub+ Standard is a free enterprise-grade event broker that supports publish/subscribe, queueing, request/reply, and streaming, along with integrated high availability (HA), and replication for disaster recovery. The PubSub+ Enterprise Evaluation Edition is an evaluation version of the PubSub+ Enterprise edition, which supports all the features of PubSub+ Standard, but with increased performance and scaling. You can download an Enterprise Evaluation tile (see VMware Tanzu](https://solace.com/downloads/)). Also, if you are interested in a support plan for PubSub+ for VMware Tanzu, contact [Solace](https://solace.com/support).
 
-The Enterprise tile is also comprised of two Event Brokers: Solace PubSub+ Standard, and Solace PubSub+ Enterprise. Contact [Solace Support](https://solace.com/support) for information on how to obtain this tile and associated support plans.
+The Enterprise tile is also comprised of two event brokers: Solace PubSub+ Standard, and Solace PubSub+ Enterprise. Contact [Solace](https://solace.com/support) for information on how to obtain this tile and associated support plans.
 
 
 ## <a id='marketplace-plans'></a> VMware Tanzu Marketplace Plans
@@ -120,10 +120,10 @@ TCP routes allow access to Solace messaging services hosted inside your VMware T
 
 Having TCP routes enables many use cases:
 
- * **Hybrid cloud:** Other Solace PubSub+ Event Brokers deployed outside VMware Tanzu can establish [Bridge](https://docs.solace.com/Features/Working-With-Message-VPN-Bridges.htm) connections to Solace PubSub+ services inside your VMware Tanzu cloud.
+ * **Hybrid cloud:** Other Solace PubSub+ Event Brokers deployed outside VMware Tanzu can establish [Bridge](https://docs.solace.com/Features/VPN/Message-VPN-Bridges-Overview.htm) connections to Solace PubSub+ services inside your VMware Tanzu cloud.
  * **External client app:** Apps deployed outside VMware Tanzu can communicate via messaging with apps deployed inside VMware Tanzu by connecting to a Solace PubSub+ service deployed in VMware Tanzu.
- * **IoT:** Devices using MQTT or REST can connect to Solace PubSub+ services from outside VMware Tanzu to communicate with your apps deployed inside VMware Tanzu, look for the *TCP Routes for IoT---MQTT Java Application Tutorial* [Getting Started Samples](http://dev.solace.com/get-started/pcf-tutorials/) with full source code available in [GitHub](https://github.com/SolaceSamples/solace-samples-cloudfoundry-java/tcp-routes-mqtt/).
- * **Mobile apps:** Mobile and web apps can use [web messaging](https://docs.solace.com/Features/Web-Messaging-Concepts/Web-Messaging-Concepts.htm) to connect to Solace PubSub+ services from outside VMware Tanzu to communicate with your apps deployed inside VMware Tanzu.
+ * **IoT:** Devices using MQTT or REST can connect to Solace PubSub+ services from outside VMware Tanzu to communicate with your apps deployed inside VMware Tanzu. Look for the TCP Routes for IoT---MQTT Java Application Tutorial [Getting Started Samples](https://tutorials.solace.dev/tanzu/) with full source code available in [GitHub](https://github.com/SolaceSamples/solace-samples-cloudfoundry-java/tcp-routes-mqtt/).
+ * **Mobile apps:** Mobile and web apps can use [web messaging](https://docs.solace.com/API/Messaging-APIs/JavaScript-API/Web-Messaging-Concepts/Web-Messaging-Concepts.htm) to connect to Solace PubSub+ services from outside VMware Tanzu to communicate with your apps deployed inside VMware Tanzu.
 
 To use TCP routes, you must [enable and configure TCP Routes at installation time](installing.html#optional_tcp_routes) with a selection of default settings for each messaging protocol you wish to use. Once enabled, TCP routes can be fine-tuned per service at service creation time.
 
@@ -141,7 +141,7 @@ You can enable the use of an LDAP server for the Solace PubSub+ Event Broker's a
 In addition to easy and natural APIs for your apps, Solace PubSub+ supports the following key features:
 
 * [Easy integration with third-party products](https://docs.solace.com/Developer-Tools/Integration-Guides/Integration-Guides.htm) such as big data, ESBs, JEE, DataPower, and more.
-* [Comprehensive authentication, authorization, and encryption](https://docs.solace.com/Overviews/Client-Authentication-Overview.htm) features to ensure that your infrastructure and information are protected at all times.
+* [Comprehensive authentication, authorization, and encryption](https://docs.solace.com/Security/Client-Authentication-Overview.htm) features to ensure that your infrastructure and information are protected at all times.
 * High-performance messaging middleware which can cost-effectively meet the needs of any app.
 * [Simplified operations](https://docs.solace.com/Management-Tools.htm) with multiple management administration interfaces.
 * [Virtualize application groups on a single Solace Event Broker](https://docs.solace.com/Configuring-and-Managing/Managing-Message-VPNs.htm) with complete message isolation through Solace Message VPNs.

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -447,8 +447,8 @@ Five Enterprise Shared service instances can be hosted on a single Enterprise Sh
 
     To set how often the upgrade task runs, do one of the following:
 
-	  + Select a preconfigured interval in **On Demand Upgrade Task Timer**.
-	  + Select **Custom Time** and enter an interval in Cron format.
+	 - Select a preconfigured interval in **On Demand Upgrade Task Timer**.
+	 - Select **Custom Time** and enter an interval in Cron format.
 
     ![alt-text=""](./images/form_general_settings_upgrade_2.png)
 
@@ -504,7 +504,7 @@ Five Enterprise Shared service instances can be hosted on a single Enterprise Sh
     no more than 2 upgrades will be performed at once regardless of what you enter in the
     Maximum On-Demand fields in the Solace tile.
 
-    See [Configuring Bosh Director](https://docs.pivotal.io/pivotalcf/2-6/om/gcp/config-manual.html) for details on how to set the number of Director Workers.
+    See [Configuring Bosh Director](https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/vmware-tanzu-ops-manager/index.html) for details on how to set the number of Director Workers.
 
 1. <a id='webhook'></a>Under **Web Hook**, you can choose to Enable or Disable.
 
@@ -539,10 +539,10 @@ Five Enterprise Shared service instances can be hosted on a single Enterprise Sh
     }
     ```
 
-    The REST endpoint must return the HTTP status code 200. Otherwise the message will remain on a queue and delivery will be reattempted repeatedly. Please see [REST Consumers](https://docs.solace.com/Features/REST-Messaging-Concepts/REST-Consumers.htm) and [Solace REST Status Codes](https://docs.solace.com/RESTMessagingPrtl/Solace-REST-Status-Codes.htm) for requirements regarding the REST endpoint.
+    The REST endpoint must return the HTTP status code 200. Otherwise the message will remain on a queue and delivery will be reattempted repeatedly. Please see [REST Consumers](https://docs.solace.com/API/REST/REST-Msging-Concepts.htm) and [Solace REST Status Codes](https://docs.solace.com/API/RESTMessagingPrtl/Solace-REST-Status-Codes.htm) for requirements regarding the REST endpoint.
     <br>
 
-    Also see [Managing REST Messaging](https://docs.solace.com/Configuring-and-Managing/Managing-REST-Messaging.htm) for more information about Solace REST Delivery Points.
+    Also see [Managing REST Messaging](https://docs.solace.com/Services/Managing-REST-Messaging.htm) for more information about Solace REST Delivery Points.
 
 2.  <a id='sb_settings'></a> Adjust service broker related settings.
 
@@ -659,7 +659,7 @@ Generated certificates are equivalent to self-signed certificates.
 
 1. (Optional) Configure **Event Broker Trusted Root Certificates**.
 These certificates are stored in the trust store on the Solace PubSub+ Event Brokers.
-They are required if you choose to use LDAP with TLS or if you want to use [Client Certificate Authentication](https://docs.solace.com/Features/Client-Authentication.htm#Client-Certificate).
+They are required if you choose to use LDAP with TLS or if you want to use [Client Certificate Authentication](https://docs.solace.com/Security/Client-Authentication-Overview.htm).
 
     ![alt-text=""](./images/form_tls_config_trusted_root_certificates_new.png)
 
@@ -669,7 +669,7 @@ They are required if you choose to use LDAP with TLS or if you want to use [Clie
 
 2. Set the **Default REST SSL Server Certificate Max Chain Depth** for newly created service instances.
 Set to 3 by default and can be any number between 0 and 8. The
-[REST SSL Server Certificate Max Chain Depth](https://docs.solace.com/Configuring-and-Managing/Managing-REST-Service.htm#Set-Max-Chain) can be changed by the service owner through the Solace PubSub+ Manager or CLI. Changes to this property do not impact existing service instances.
+[REST SSL Server Certificate Max Chain Depth](https://docs.solace.com/Services/Managing-REST-Service.htm#Set-Max-Chain) can be changed by the service owner through the Solace PubSub+ Broker Manager or CLI. Changes to this property do not impact existing service instances.
 
     ![alt-text=""](./images/form_tls_config_rest_server_cert_max_chain_depth.png)
 
@@ -741,7 +741,7 @@ Set to 3 by default and can be any number between 0 and 8. The
 
     ![alt-text=""](./images/form_management_access_monitor_user.png)
 
-    You can create a management interface user with read-only access both to the global configuration and the VPN-level configuration. Please see [CLI User Access Levels](https://docs.solace.com/Configuring-and-Managing/CLI-User-Access-Levels.htm) for details about the access levels.
+    You can create a management interface user with read-only access both to the global configuration and the VPN-level configuration. Please see [CLI User Access Levels](https://docs.solace.com/Admin/CLI-User-Access-Levels.htm) for details about the access levels.
 
 7. Click **Save**.
 
@@ -821,7 +821,7 @@ In order to have an effective LDAP configuration, configure LDAP for [Management
 
     ![alt-text=""](./images/form_oauth_2.png)
 
-    Please refer to the [Client Authentication Overview](https://docs.solace.com/Overviews/Client-Authentication-Overview.htm) page for field documentation.
+    Please refer to the [Client Authentication Overview](https://docs.solace.com/Security/Client-Authentication-Overview.htm) page for field documentation.
 
     Changing the above configuration does not update pre-existing message VPNs. The default OAuth provider is only created on new message VPNs.
 
@@ -991,7 +991,7 @@ Upgrades are non-service-affecting for high-availability plans `Enterprise Large
 
 An application using an HA service experiences at least one switch-over during an upgrade, and at most two switch-overs.
 
-See our [Getting Started Samples](http://dev.solace.com/get-started/pcf-tutorials/) with full source code available in [GitHub](https://github.com/SolaceSamples/solace-samples-cloudfoundry-java) for some examples of how HA connections are used, as well as [Configuring-Client-Connections](https://docs.solace.com/Solace-Messaging-APIs/Developer-Guide/Configuring-Connection-T.htm) for additional information on client connection setup to allow for switch-overs during upgrades.
+See our [Getting Started Samples](https://tutorials.solace.dev/tanzu/) with full source code available in [GitHub](https://github.com/SolaceSamples/solace-samples-cloudfoundry-java) for some examples of how HA connections are used, as well as [Configuring-Client-Connections](https://docs.solace.com/API/API-Developer-Guide/Configuring-Connection-T.htm) for additional information on client connection setup to allow for switch-overs during upgrades.
 
 The upgrade process is designed to keep services available.
 

--- a/docs-content/managing.html.md.erb
+++ b/docs-content/managing.html.md.erb
@@ -3,14 +3,14 @@ title: Managing the Message VPN
 owner: Partners
 ---
 
-Developers can manage the Message VPN associated with a service instance by using the Dashboard URL of the service and by connecting to the Solace PubSub+ Event Broker via the PubSub+ Manager web browser based interface.
+Developers can manage the Message VPN associated with a service instance by using the Dashboard URL of the service and by connecting to the Solace PubSub+ Event Broker via the PubSub+ Broker Manager web browser based interface.
 
 
 ## <a id='solace_pubsub_service_dashboard'></a> Solace PubSub+ Service Dashboard
 
 The Solace PubSub+ Service Dashboard offers the following functionality:
 
-* A link to the [Solace PubSub+ Manager](#solace_pubsub_manager).
+* A link to the [Solace PubSub+ Borker Manager](#solace_pubsub_manager).
 * Manage Client Profiles and their configuration.
 * Capture a backup of basic service configuration and subsequently restore it.
 * Elect to receive an upgrade when an upgrade is available if [user controlled upgrades are enabled](installing.html#user-controlled-upgrades).
@@ -37,7 +37,7 @@ Users with manage access will be able to utilize the features of the service das
 
 Client profiles are assigned to client usernames so that a common configuration can be applied to groups of clients.
 
-The Client Profile Management section displays existing client profiles and offers the ability to create, update, and delete client profiles on the message VPN. While creating and updating client profiles, select the client profile capabilities to turn ON/OFF. For more information about client profiles, please consult Solace's documentation: [Client Profile](https://docs.solace.com/PubSub-Basics/Core-Concepts-Solace-Event-Broker-Concepts.htm#client-profile) and [Client Profile Configuration](https://docs.solace.com/Configuring-and-Managing/Configuring-Client-Profiles.htm)
+The Client Profile Management section displays existing client profiles and offers the ability to create, update, and delete client profiles on the message VPN. While creating and updating client profiles, select the client profile capabilities to turn ON/OFF. For more information about client profiles, see [Clients Profiles](https://docs.solace.com/Security/Client-Authorization-Overview.htm) and [Configuring Clients with Client Profiles](https://docs.solace.com/Security/Assigning-Client-Profiles.htm)
 
 The client profile highlighted in light green is the selected default client profile. New client usernames created through Cloud Foundry are automatically assigned this client profile. To select a different default client profile, use the dropdown menu that can be found at the bottom of the client profile table. Changing the default client profile does not modify existing client usernames, the change only applies to new client usernames.
 
@@ -53,18 +53,18 @@ At this point it is not intended to do a full backup and restore on the same ser
 
 **Note that performing a restore will delete all persisted messages and will leave the VPN with only the objects that existed when the backup was performed.**
 
-## <a id='solace_pubsub_manager'></a> Solace PubSub+ Manager
+## <a id='solace_pubsub_manager'></a> Solace PubSub+ Broker Manager
 
-The Solace PubSub+ Event Broker includes a browser based management interface for the Solace PubSub+ services.
-The Solace PubSub+ Manager is accessible when a service is created from a link in the [Solace PubSub+ Service Dashboard](#solace_pubsub_service_dashboard).
+The PubSub+ Event Broker includes a browser based management interface for the Solace PubSub+ services.
+The PubSub+ Broker Manager is accessible when a service is created from a link in the [Solace PubSub+ Service Dashboard](#solace_pubsub_service_dashboard).
 
-### <a id='sample_pubsub_manager'></a> Sample PubSub+ Manager
+### <a id='sample_pubsub_manager'></a> Sample PubSub+ Broker Manager
 
   ![alt-text=""](./images/sample_pubsub_manager_new.png)
 
-### Restrictions on the Use of the PubSub+ Manager
+### Restrictions on the Use of the PubSub+ Broker Manager
 
-There are some actions that you must not perform in the PubSub+ Manager:
+There are some actions that you must not perform in the PubSub+ Broker Manager:
 
 1. Do not change anything on the **Message VPN/Services** page. Settings such as
 TLS configuration must be managed through the tile.
@@ -134,7 +134,7 @@ To retrieve the information required to connect to the Solace PubSub+ Event Brok
 
 The `managementHostnames` and `activeManagementHostname` are externally accessible FQDNs and can be used directly from within SolAdmin using standard ports for HTTP (`80`) and HTTPS (`443`). The procedure is as follows:
 
-1. Download and install the SolAdmin administration tool from the [Solace Developers Portal Download Page](http://dev.solace.com/downloads/).
+1. Download and install the SolAdmin administration tool from the [Solace Downloads page](https://solace.com/downloads/).
 
 1. Start SolAdmin.
 

--- a/docs-content/service-instances.html.md.erb
+++ b/docs-content/service-instances.html.md.erb
@@ -8,7 +8,7 @@ This topic describes how developers can manage instances of Solace PubSub+ servi
 
 ## <a id='about_solace_service_instance'></a> About the Solace Service Instance
 
-A Solace Service Instance represents a Message VPN on a Solace PubSub+ Event Broker. A Message VPN allows for many separate apps to share a single Event Broker while still remaining independent and separated. For more information about Message VPNs, see [Core Concepts](https://docs.solace.com/Features/Core-Concepts.htm).
+A Solace Service Instance represents a Message VPN on a Solace PubSub+ Event Broker. A Message VPN allows for many separate apps to share a single Event Broker while still remaining independent and separated. For more information, see [Message VPNs](https://docs.solace.com/Features/VPN/Managing-Message-VPNs.htm).
 
 After deploying the Solace PubSub+ for VMware Tanzu tile, the Solace PubSub+ service appears in the Marketplace. Developers can use either the Cloud Foundry Command Line Interface (cf CLI) or Apps Manager to create an instance of the service which they can make available to apps that need to exchange messages.
 
@@ -80,7 +80,7 @@ The parameters applied can be viewed in the service instance dashboard.
     * `health_check_tcp_route_primary_port`, `health_check_tcp_route_backup_port`
 
 4. <a id='vpn_options'></a> The top level configuration option `vpnOptions` can be provided to configure various properties on the VPN.
-  1. [Service REST Mode](https://docs.solace.com/Open-APIs-Protocols/REST-get-start.htm#When) can be set
+  1. [Service REST Mode](https://docs.solace.com/API/REST/REST-get-start.htm#When) can be set
 to either messaging or gateway. The mode can be set with the `vpnOptions.serviceRestMode` json property with valid values `gateway` or `messaging`.
 This property defaults to messaging.
 

--- a/docs-content/service-plans.html.md.erb
+++ b/docs-content/service-plans.html.md.erb
@@ -134,7 +134,7 @@ Service Plans can be customized by the operator allowing to adjust the plans for
 
   <tr>
   <th>Maximum Queue Messages</th>
-  <td>Sets the maximum number of messages that can be queued for delivery to consumers. Sufficient system resources need to be available on the VM; see <a href='https://docs.solace.com/Configuring-and-Managing/SW-Broker-Specific-Config/System-Scaling-Parameters.htm'> Solace documentation for specific requirements</a>. Consider this setting while selecting a VM Type for your deployment.
+  <td>Sets the maximum number of messages that can be queued for delivery to consumers. Sufficient system resources need to be available on the VM; see <a href='https://docs.solace.com/Software-Broker/SW-Broker-Configuration-Defaults.htm'> Solace documentation for specific requirements</a>. Consider this setting while selecting a VM Type for your deployment.
   <ul>
   <li>This setting is only applied to new deployments. Existing deployments won't be updated.</li>
   <ul>
@@ -191,7 +191,7 @@ Service Plans can be customized by the operator allowing to adjust the plans for
 <p id='tableNote1' class="note"><strong><sup>1</sup> Note</strong>: Please set the same matching <strong>VM Type</strong> and <strong>Disk Type</strong> if you have <strong>Operator Allocated</strong> instances in <a href='installing.html#required_resource_config'>Resource Config</a>.</p>
 <p id='tableNote2' class="note"><strong><sup>2</sup> Note</strong>: Please consider if using the same Network and AZs used in <a href='installing.html#required_azs_and_network'>Assign AZs and Networks</a> for Operator Allocated instances.</p>
 <p id='tableNote3' class="note"><strong><sup>3</sup> Note</strong>: To configure VM extensions on tile created instance groups, see <a href='https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/vmware-tanzu-ops-manager/install-custom-vm-extensions.html'>Managing Custom VM Extensions</a></p>
-<p id='tableNote4' class="note"><strong><sup>4</sup> Note</strong>: See <a href="https://docs.solace.com/Configuring-and-Managing/Product-Key.htm">Product Keys</a></p>
+<p id='tableNote4' class="note"><strong><sup>4</sup> Note</strong>: See <a href="https://docs.solace.com/Admin/Product-Key.htm">Product Keys</a></p>
 
 ## <a id='general_plan_settings'></a> General Settings
 
@@ -201,7 +201,7 @@ The Monitor **VM Type** and **Disk Type** settings apply to all on-demand plans 
 
 A deployment of Solace PubSub+ Event Broker will attempt to maximize the use of the underlying resources on any given **VM Type**.
 
-The deployment will auto select the [maximum client connection scaling parameter](https://docs.solace.com/Configuring-and-Managing/SW-Broker-Specific-Config/System-Scaling-Parameters.htm) based on the following:
+The deployment will auto select the [maximum client connection scaling parameter](https://docs.solace.com/Software-Broker/System-Scaling-Parameters.htm) based on the following:
 
 * number of detected CPUs,
 * amount of detected RAM,

--- a/docs-content/troubleshooting.html.md.erb
+++ b/docs-content/troubleshooting.html.md.erb
@@ -5,7 +5,7 @@ owner: Partners
 
 This topic describes how operators and developers can troubleshoot instances of Solace PubSub+ services.
 
-A [Solace PubSub+ Service Instance](service-instances.html) is backed by a Message VPN on one or many Solace PubSub+ Software Event Broker, depending on the chosen plan.
+A [Solace PubSub+ Service Instance](service-instances.html) is backed by a Message VPN on one or more PubSub+ Software Event Brokers, depending on the plan you've chosen.
 
 You can discover the Solace PubSub+ Software Event Broker backing a service instance from the [Solace PubSub+ Credentials](credentials.html) which become available by [binding](bindings.html) an app to the instance or [creating a service key](service-keys.html) for the instance.
 
@@ -343,7 +343,7 @@ Endpoints owned by v002.cu000001 must first be deleted:
         Topics Endpoints: [ someTPE ]
 </pre>
 </td></tr>
-<tr><th>Explanation</th><td>The service broker will reject unbinding when the client-username that was used by the application owns <a href='https://docs.solace.com/Features/Endpoints.htm'>Endpoints</a> such as Queues and Topic Endpoints while the current Orphaned Resource Policy is to <b>Abort</b></td></tr>
+<tr><th>Explanation</th><td>The service broker will reject unbinding when the client-username that was used by the application owns <a href='https://docs.solace.com/Messaging/Guaranteed-Msg/Endpoints.htm'>Endpoints</a> such as Queues and Topic Endpoints while the current Orphaned Resource Policy is to <b>Abort</b></td></tr>
 <tr><th>Possible Action(s)</th><td>Delete the Endpoints before unbinding. Alternatively you can adjust the <a href='service-instances.html#service_orphaned_resource_policy'>Service Orphaned Resource Policy</a>.</td></tr>
 </table>
 <br>
@@ -397,14 +397,14 @@ logout of the dashboard by clicking the user icon in the top right corner and cl
 </table>
 
 <table border="1" class="nice">
-<tr><th colspan=2><a id='dashboard_permission_error'></a>Solace PubSub+ Manager Redirected to Port 943</th></th>
+<tr><th colspan=2><a id='dashboard_permission_error'></a>Solace PubSub+ Broker Manager Redirected to Port 943</th></th>
 <tr><th>Operation</th><td>
-Accessing Solace PubSub+ Manager
+Accessing PubSub+ Broker Manager
 </td></tr>
 <tr><th>Error</th><td>
 The page never loads and the URL contains the port 943.
 </td></tr>
-<tr><th>Explanation</th><td>If the Solace PubSub+ Manager was accessed during an upgrade to v2.15.0, it is possible that the browser got redirected to port 943.</td></tr>
+<tr><th>Explanation</th><td>If the PubSub+ Broker Manager was accessed during an upgrade to v2.15.0, it is possible that the browser got redirected to port 943.</td></tr>
 <tr><th>Possible Action(s)</th><td>Wait for the upgrade to complete. Empty the browser's cache and try again, the webpage should no longer be improperly redirected.</td></tr>
 </table>
 


### PR DESCRIPTION
Fix all links related to dev.solace.com and pointed to the right location. Fixed links that were stale or incorrectly pointed to information on Solace.com. Fixed branding of Broker Manager.